### PR TITLE
Add --skip-bump-dependencies flag

### DIFF
--- a/bin/set-versions
+++ b/bin/set-versions
@@ -11,10 +11,13 @@ const cli = meow(
 
     Options
 
-        --workspaces, -w Use workspaces from package.json.
-                         If no version is specified, it uses the version
-                         from package.json.
+        --workspaces, -w            Use workspaces from package.json.
+                                    If no version is specified, it uses the version
+                                    from package.json.
     
+        --skip-bump-dependencies    Only update packages versions but do not update
+                                    dependencies between the packages of workspace.
+
     Examples
 
       $ set-versions 2.0.0 packages/*/package.json
@@ -34,9 +37,16 @@ const cli = meow(
         type: 'boolean',
         alias: 'w',
       },
+      skipBumpDependencies: {
+        type: 'boolean',
+      },
     },
   }
 );
+
+const options = {
+  bumpDependencies: !cli.flags.skipBumpDependencies,
+};
 
 if (cli.flags.workspaces) {
   if (cli.input.length > 1) {
@@ -48,11 +58,15 @@ if (cli.flags.workspaces) {
   resolveWorkspaces().then(({ root, packages }) => {
     const currentRootVersion = root.package.version;
     const finalVersion = cli.input[0] || currentRootVersion;
-    setVersions(finalVersion, [
-      ...(finalVersion !== currentRootVersion ? [root.packagePath] : []),
-      ...packages,
-    ]);
+    setVersions(
+      finalVersion,
+      [
+        ...(finalVersion !== currentRootVersion ? [root.packagePath] : []),
+        ...packages,
+      ],
+      options
+    );
   });
 } else {
-  setVersions(cli.input[0], cli.input.slice(1));
+  setVersions(cli.input[0], cli.input.slice(1), options);
 }

--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ const updateDependencies = (dependencies, version, names) =>
     {}
   );
 
-function updateVersions(version, filesAndPackages) {
+function updateVersions(version, filesAndPackages, options) {
   const names = filesAndPackages
     .map(({ contents: { name } }) => name)
     .filter(name => name !== undefined);
@@ -27,11 +27,18 @@ function updateVersions(version, filesAndPackages) {
   return filesAndPackages.map(({ file, contents }) => {
     const newContents = JSON.parse(JSON.stringify(contents));
     newContents.version = version;
-    dependencyTypes.forEach(dep => {
-      if (dep in newContents) {
-        newContents[dep] = updateDependencies(newContents[dep], version, names);
-      }
-    });
+
+    if (options.bumpDependencies) {
+      dependencyTypes.forEach(dep => {
+        if (dep in newContents) {
+          newContents[dep] = updateDependencies(
+            newContents[dep],
+            version,
+            names
+          );
+        }
+      });
+    }
 
     return {
       file,
@@ -40,7 +47,7 @@ function updateVersions(version, filesAndPackages) {
   });
 }
 
-async function setVersions(version, packages) {
+async function setVersions(version, packages, options) {
   const filesAndPackages = await Promise.all(
     packages.map(file =>
       readFile(file).then(contents => ({
@@ -50,7 +57,7 @@ async function setVersions(version, packages) {
     )
   );
 
-  const newPackages = updateVersions(version, filesAndPackages);
+  const newPackages = updateVersions(version, filesAndPackages, options);
 
   return Promise.all(
     newPackages.map(({ file, contents }) =>

--- a/tests/set-versions.test.js
+++ b/tests/set-versions.test.js
@@ -85,9 +85,9 @@ test('Set version with version and files args', async () => {
   ];
   await execa(setVersions, ['5.0.0', ...packages], { cwd: testFixturePath2 });
 
-  const [aPkg, bPkg] = (await Promise.all(
-    packages.map(pkgPath => readFile(pkgPath))
-  )).map(json => JSON.parse(json));
+  const [aPkg, bPkg] = (
+    await Promise.all(packages.map(pkgPath => readFile(pkgPath)))
+  ).map(json => JSON.parse(json));
 
   expect(aPkg.version).toBe('5.0.0');
   expect(bPkg.version).toBe('5.0.0');
@@ -97,11 +97,13 @@ test('Set version with version and files args', async () => {
 test('Set versions with --workspaces', async () => {
   await execa(setVersions, ['--workspaces'], { cwd: testFixturePath });
 
-  const [aPkg, bPkg, cPkg] = (await Promise.all([
-    readFile(path.join(testFixturePath, 'packages', 'a', 'package.json')),
-    readFile(path.join(testFixturePath, 'packages', 'b', 'package.json')),
-    readFile(path.join(testFixturePath, 'packages', 'c', 'package.json')),
-  ])).map(json => JSON.parse(json));
+  const [aPkg, bPkg, cPkg] = (
+    await Promise.all([
+      readFile(path.join(testFixturePath, 'packages', 'a', 'package.json')),
+      readFile(path.join(testFixturePath, 'packages', 'b', 'package.json')),
+      readFile(path.join(testFixturePath, 'packages', 'c', 'package.json')),
+    ])
+  ).map(json => JSON.parse(json));
 
   expect(aPkg.version).toBe('2.0.0');
   expect(bPkg.version).toBe('2.0.0');
@@ -116,10 +118,12 @@ test('Set versions reading workspace.packages', async () => {
     cwd: testFixturePath2,
   });
 
-  const [aPkg, bPkg] = (await Promise.all([
-    readFile(path.join(testFixturePath2, 'packages', 'a', 'package.json')),
-    readFile(path.join(testFixturePath2, 'packages', 'b', 'package.json')),
-  ])).map(json => JSON.parse(json));
+  const [aPkg, bPkg] = (
+    await Promise.all([
+      readFile(path.join(testFixturePath2, 'packages', 'a', 'package.json')),
+      readFile(path.join(testFixturePath2, 'packages', 'b', 'package.json')),
+    ])
+  ).map(json => JSON.parse(json));
 
   expect(aPkg.version).toBe('5.0.0');
   expect(bPkg.version).toBe('5.0.0');
@@ -129,12 +133,14 @@ test('Set versions reading workspace.packages', async () => {
 test('Set versions with --workspaces and version', async () => {
   await execa(setVersions, ['6.0.0', '--workspaces'], { cwd: testFixturePath });
 
-  const [rootPkg, aPkg, bPkg, cPkg] = (await Promise.all([
-    readFile(path.join(testFixturePath, 'package.json')),
-    readFile(path.join(testFixturePath, 'packages', 'a', 'package.json')),
-    readFile(path.join(testFixturePath, 'packages', 'b', 'package.json')),
-    readFile(path.join(testFixturePath, 'packages', 'c', 'package.json')),
-  ])).map(json => JSON.parse(json));
+  const [rootPkg, aPkg, bPkg, cPkg] = (
+    await Promise.all([
+      readFile(path.join(testFixturePath, 'package.json')),
+      readFile(path.join(testFixturePath, 'packages', 'a', 'package.json')),
+      readFile(path.join(testFixturePath, 'packages', 'b', 'package.json')),
+      readFile(path.join(testFixturePath, 'packages', 'c', 'package.json')),
+    ])
+  ).map(json => JSON.parse(json));
 
   expect(rootPkg.version).toBe('6.0.0');
   expect(aPkg.version).toBe('6.0.0');
@@ -142,5 +148,30 @@ test('Set versions with --workspaces and version', async () => {
   expect(cPkg.version).toBe('6.0.0');
   expect(bPkg.dependencies['pre-a']).toBe('6.0.0');
   expect(bPkg.dependencies['other-c']).toBe('6.0.0');
+  expect(bPkg.dependencies['other-d']).toBe('4.1.3');
+});
+
+test('Allows to skip update of dependencies between the packages', async () => {
+  await execa(
+    setVersions,
+    ['6.0.0', '--workspaces', '--skip-bump-dependencies'],
+    { cwd: testFixturePath }
+  );
+
+  const [rootPkg, aPkg, bPkg, cPkg] = (
+    await Promise.all([
+      readFile(path.join(testFixturePath, 'package.json')),
+      readFile(path.join(testFixturePath, 'packages', 'a', 'package.json')),
+      readFile(path.join(testFixturePath, 'packages', 'b', 'package.json')),
+      readFile(path.join(testFixturePath, 'packages', 'c', 'package.json')),
+    ])
+  ).map(json => JSON.parse(json));
+
+  expect(rootPkg.version).toBe('6.0.0');
+  expect(aPkg.version).toBe('6.0.0');
+  expect(bPkg.version).toBe('6.0.0');
+  expect(cPkg.version).toBe('6.0.0');
+  expect(bPkg.dependencies['pre-a']).toBe('1.0.0');
+  expect(bPkg.dependencies['other-c']).toBe('1.0.0');
   expect(bPkg.dependencies['other-d']).toBe('4.1.3');
 });


### PR DESCRIPTION
### Use case

We have a monorepo with main application and several packages and we prefer not to specify versions of these packages in main app's dependencies:

```json
{
  "version": "1.0.0",
  "dependencies": {
    "packageA": "*",
    "packageB": "*"
  }
}
```

When new version is released we bump versions of the main app and all the packages but want to keep dependencies unchanged (specified as `*`).

Currently it was impossible because `yarn set versions 1.0.1 --workspaces` updates dependencies section, too.

### Solution

I added a `--skip-bump-dependencies` flag that allows to skip dependencies update step.

### Example

#### Before

`app/package.json`

```json
{
  "version": "1.0.0",
  "dependencies": {
    "packageA": "*",
  }
}
```

`packageA/package.json`

```json
{
  "version": "1.0.0",
}
```

#### After `yarn set-versions 1.0.1 --workspaces --skip-bump-dependencies`

`app/package.json`

```json
{
  "version": "1.0.1",
  "dependencies": {
    "packageA": "*",
  }
}
```

`packageA/package.json`

```json
{
  "version": "1.0.1",
}
```
